### PR TITLE
Build a dist pkg and upload to pypi

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,3 +29,27 @@ jobs:
       run: |
         pip install pre-commit
         pre-commit run -a
+    - name: Install pep517
+      run: >-
+        python -m
+        pip install
+        pep517
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        pep517.build
+        --source
+        --binary
+        --out-dir dist/
+        .
+    - name: Publish distribution pkg to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution pkg to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
See #6 

Most of the hard work is already taken care of now that there is a `setup.py`, but I can't verify if this is everything (looks like it though...).

@afparsons @Hironsan to make this thing work we'll be needing API tokens and a true pypi account. Can I help there?