### PR TITLE
Handle filepond api

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -588,9 +588,13 @@ class DoccanoClient(_Router):
     def post_doc_upload(
         self,
         project_id: int,
-        file_format: str,
         file_name: str,
         file_path: str = './',
+        column_data: str = "text",
+        column_label: str = "label",
+        delimiter: str  = "",
+        encoding: str = "utf_8",
+        format: str = "JSONL"
     ) -> requests.models.Response:
         """
         Uploads a file to a Doccano project.
@@ -601,29 +605,24 @@ class DoccanoClient(_Router):
                                `conll`.
             file_name (str): The name of the file.
             file_path (str): The parent path of the file. Defaults to `./`.
+            column_data (str): Name of the column with data (text for annotation)
+            column_label (str): Name of the column with labels (labels for annotation)
+            delimiter (str): Delimeter for the current dataset
+            encoding (str): Current file encoding
+            format (str): The file format, ex: `plain`, `json`, or `conll`.
+
 
         Returns:
             requests.models.Response: The request response.
         """
-        files = {
-            'file': (
-                file_name,
-                open(os.path.join(file_path, file_name), 'rb')
-            )
-        }
-        data = {
-            'file': (
-                file_name,
-                open(os.path.join(file_path, file_name), 'rb')
-            ),
-            'format': file_format
-        }
-        return self.post(
-            'v1/projects/{project_id}/docs/upload'.format(
-                project_id=project_id
-            ),
-            files=files,
-            data=data
+        return self.post_doc_upload_binary(
+            project_id=project_id,
+            files=[open(os.path.join(file_path, file_name), 'rb')],
+            column_data=column_data,
+            column_label=column_label,
+            delimiter=delimiter,
+            encoding=encoding,
+            format=format
         )
 
     def post_approve_labels(


### PR DESCRIPTION
# Description

This PR adds file pond (used in the newest doccano version) functionality to this library. Also now we can upload not only saved files but file objects as well. 

NB! This PR adds breaking changes (even if the compatibility is already broken with the newest doccano versions) but from this update, the client will use file pond instead of classic file upload, this lib won't be compatible with the previous doccano versions

Fixes #24 
