### PR TITLE
add delete_project

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -205,6 +205,22 @@ class DoccanoClient(_Router):
                 }
         return self.post('v1/projects', data=payload)
 
+    def delete_project(
+        self,
+        project_id: int
+    ) -> requests.models.Response:
+        """
+        Deletes a project.
+
+        Args:
+            project_id (int)" project identifier
+
+        Returns:
+            requests.models.Response: The request response.
+        """
+        url = 'v1/projects/{}'.format(project_id)
+        return self.delete(url)
+
     def create_document(
             self,
             project_id: int,

--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -213,7 +213,7 @@ class DoccanoClient(_Router):
         Deletes a project.
 
         Args:
-            project_id (int)" project identifier
+            project_id (int): A project identifier.
 
         Returns:
             requests.models.Response: The request response.


### PR DESCRIPTION
# Description
Adds a delete_project method.

```python
def delete_project(
    self,
    project_id: int
) -> requests.models.Response:
    """
    Deletes a project.

    Args:
        project_id (int): A project identifier.

    Returns:
        requests.models.Response: The request response.
    """
    url = 'v1/projects/{}'.format(project_id)
    return self.delete(url)
```

This method calls a delete project API provided a `generics.RetrieveUpdateDestroyAPIView` class:
https://github.com/doccano/doccano/blob/cc36406/backend/api/views/example.py#L65-L70
