### PR TITLE
Dummy referrer header for CSRF protection

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -161,6 +161,7 @@ class DoccanoClient(_Router):
     def __init__(self, baseurl: str, username: str, password: str):
         self.baseurl = baseurl if baseurl[-1] == "/" else baseurl + "/"
         self.session = requests.Session()
+        self.session.headers = {"referer": self.baseurl}
         self._login(username, password)
 
     def _login(self, username: str, password: str) -> requests.models.Response:


### PR DESCRIPTION
# Description

* Set value for `referer` header to avoid failing the CSRF protection when doing HTTPS requests

Fixes #46 
