### PR TITLE
Fix: remove mutable default arg

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -300,11 +300,11 @@ class DoccanoClient(_Router):
         return self.update(url, data=payload)
 
     def create_document(
-        self, 
-        project_id: int, 
-        text: str, 
-        annotations: typing.Optional[typing.List] = None, 
-        annotation_approver: str = None
+        self,
+        project_id: int,
+        text: str,
+        annotations: typing.Optional[typing.List] = None,
+        annotation_approver: str = None,
     ) -> requests.models.Response:
         """Creates a document.
 
@@ -317,10 +317,10 @@ class DoccanoClient(_Router):
         Returns:
             requests.models.Response: The request response
         """
-        
+
         if annotations == None:
             annotations = []
-        
+
         url = "v1/projects/{}/docs".format(project_id)
         data = {
             "text": text,

--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -300,7 +300,11 @@ class DoccanoClient(_Router):
         return self.update(url, data=payload)
 
     def create_document(
-        self, project_id: int, text: str, annotations: list = [], annotation_approver: str = None
+        self, 
+        project_id: int, 
+        text: str, 
+        annotations: typing.Optional[typing.List] = None, 
+        annotation_approver: str = None
     ) -> requests.models.Response:
         """Creates a document.
 
@@ -313,6 +317,10 @@ class DoccanoClient(_Router):
         Returns:
             requests.models.Response: The request response
         """
+        
+        if annotations == None:
+            annotations = []
+        
         url = "v1/projects/{}/docs".format(project_id)
         data = {
             "text": text,


### PR DESCRIPTION
# Description

Mutable default arguments cause unexpected behaviour:

```python
def append(number, number_list=[]):
    number_list.append(number)
    print(number_list)
    return number_list

append(5) # expecting: [5], actual: [5]
append(7) # expecting: [7], actual: [5, 7]
append(2) # expecting: [2], actual: [5, 7, 2]
```

Fixes # (issue)

* removed list as default argument as described in [this blogpost](https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html)