### PR TITLE
remove unused Approve API

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -740,25 +740,6 @@ class DoccanoClient(_Router):
             as_json=False,
         )
 
-    def post_approval(self, project_id: int, doc_id: int, approved: bool):
-        """Marks a document as approved or not
-
-        Args:
-            project_id (int): The project id number
-            doc_id (int): The document to have its approval setting changed
-            approved (bool): If true, the approver will be set to the
-                             logged in user, else the approver will be set to None
-
-        Returns:
-            dict: {'id': <document id>, 'annotation_approver': <username>}
-        """
-        return self.post(
-            "v1/projects/{project_id}/approval/{doc_id}".format(
-                project_id=project_id, doc_id=doc_id
-            ),
-            json={"approved": approved},
-        )
-
     def post_approve_labels(self, project_id: int, doc_id: int) -> requests.models.Response:
         return self.post(
             "v1/projects/{project_id}/docs/{doc_id}/approve-labels".format(


### PR DESCRIPTION
# Description
- remove `post_approval` method
  - because this API is unused
  - It was also removed from doccano.
    - https://github.com/doccano/doccano/pull/1647

