### PR TITLE
Fix/task arg

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -601,7 +601,7 @@ class DoccanoClient(_Router):
             )
         )
 
-    def get_category_type_list(self, project_id: int) -> request.models.Response:
+    def get_category_type_list(self, project_id: int) -> requests.models.Response:
         """Gets a list of category_types in a given project.
 
         Args:
@@ -684,7 +684,7 @@ class DoccanoClient(_Router):
         }
         return self.update(url, data=label_payload)
 
-    def get_relation_type_list(self, project_id: int) -> request.models.Response:
+    def get_relation_type_list(self, project_id: int) -> requests.models.Response:
         """Gets a list of relation_types in a given project.
 
         Args:
@@ -695,7 +695,7 @@ class DoccanoClient(_Router):
         """
         return self.get("v1/projects/{project_id}/relation-types".format(project_id=project_id))
 
-    def get_relation_type_detail(self, project_id: int, relation_type_id: int) -> request.models.Response:
+    def get_relation_type_detail(self, project_id: int, relation_type_id: int) -> requests.models.Response:
         """Gets details of a specific relation type.
 
         Args:
@@ -707,7 +707,7 @@ class DoccanoClient(_Router):
         """
         return self.get("v1/projects/{project_id}/relation-types/{relation_type_id}".format(project_id=project_id, relation_type_id=relation_type_id))
 
-    def create_relation_type(self, project_id: int, text: str, text_color: str = "#ffffff", background_color: str = "#cdcdcd", prefix_key: str = None, suffix_key: str = None) -> request.models.Response:
+    def create_relation_type(self, project_id: int, text: str, text_color: str = "#ffffff", background_color: str = "#cdcdcd", prefix_key: str = None, suffix_key: str = None) -> requests.models.Response:
         """Creates a relation_type to be used for annotating a document.
 
         Args:
@@ -740,7 +740,7 @@ class DoccanoClient(_Router):
                         text_color: str = "#ffffff",
                         background_color: str = "#cdcdcd",
                         prefix_key: str = None,
-                        suffix_key: str = None) -> request.models.Response:
+                        suffix_key: str = None) -> requests.models.Response:
         """Updates a relation_type.
 
         Args:

--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -922,6 +922,7 @@ class DoccanoClient(_Router):
             delimiter=delimiter,
             encoding=encoding,
             format=format,
+            task=task
         )
 
     def post_members(

--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -877,7 +877,7 @@ class DoccanoClient(_Router):
         delimiter: str = "",
         encoding: str = "utf_8",
         format: str = "JSONL",
-        task: str = "SequenceLabeling"
+        task: str = "SequenceLabeling",
     ) -> requests.models.Response:
         """Upload documents to doccano
 
@@ -944,7 +944,7 @@ class DoccanoClient(_Router):
         delimiter: str = "",
         encoding: str = "utf_8",
         format: str = "JSONL",
-        task: str = "SequenceLabeling"
+        task: str = "SequenceLabeling",
     ) -> requests.models.Response:
         """Uploads a file to a Doccano project.
 
@@ -970,7 +970,7 @@ class DoccanoClient(_Router):
             delimiter=delimiter,
             encoding=encoding,
             format=format,
-            task=task
+            task=task,
         )
 
     def post_members(

--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -831,6 +831,7 @@ class DoccanoClient(_Router):
         delimiter: str = "",
         encoding: str = "utf_8",
         format: str = "JSONL",
+        task: str = "SequenceLabeling"
     ) -> requests.models.Response:
         """Upload documents to doccano
 
@@ -842,6 +843,7 @@ class DoccanoClient(_Router):
             delimiter (str): Delimeter for the current dataset
             encoding (str): Current file encoding
             format (str): The file format, ex: `plain`, `json`, or `conll`.
+            task (str): task type
 
         Returns:
             requests.models.Response: The request response.
@@ -880,6 +882,7 @@ class DoccanoClient(_Router):
             "encoding": encoding,
             "format": format,
             "uploadIds": upload_ids,
+            "task": task
         }
         return self.post(f"v1/projects/{project_id}/upload", json=upload_data)
 
@@ -893,6 +896,7 @@ class DoccanoClient(_Router):
         delimiter: str = "",
         encoding: str = "utf_8",
         format: str = "JSONL",
+        task: str = "SequenceLabeling"
     ) -> requests.models.Response:
         """Uploads a file to a Doccano project.
 
@@ -905,6 +909,7 @@ class DoccanoClient(_Router):
             delimiter (str): Delimeter for the current dataset
             encoding (str): Current file encoding
             format (str): The file format, ex: `plain`, `json`, or `conll`.
+            task (str): task type
 
         Returns:
             requests.models.Response: The request response.

--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -843,7 +843,7 @@ class DoccanoClient(_Router):
             delimiter (str): Delimeter for the current dataset
             encoding (str): Current file encoding
             format (str): The file format, ex: `plain`, `json`, or `conll`.
-            task (str): task type
+            task (str): task type, ex. `SequenceLabeling`, `TextClassification`
 
         Returns:
             requests.models.Response: The request response.
@@ -909,7 +909,7 @@ class DoccanoClient(_Router):
             delimiter (str): Delimeter for the current dataset
             encoding (str): Current file encoding
             format (str): The file format, ex: `plain`, `json`, or `conll`.
-            task (str): task type
+            task (str): task type, ex. `SequenceLabeling`, `TextClassification`
 
         Returns:
             requests.models.Response: The request response.


### PR DESCRIPTION
# Description

When the task type is not provided, the server gives a 500 error for **/post_doc_upload**. Tested with Doccano v.1.7.0.

Also, fix "NameError: name 'request' is not defined."