### PR TITLE
FIX change endpoint to post member and fix roles parsing

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -987,19 +987,16 @@ class DoccanoClient(_Router):
             assert len(user) >= 1, "username {username} not found".format(username=username)
             user = user[0]
 
-            role = list(filter(lambda role_info: role_info["rolename"] == rolename, res_roles))
-            assert len(role) >= 1, "rolename {rolename} not found".format(rolename=rolename)
+            role = list(filter(lambda role_info: role_info["name"] == rolename, res_roles))
+            assert len(role) >= 1, "role name {rolename} not found".format(rolename=rolename)
             role = role[0]
 
             arr_response.append(
                 self.post(
-                    "v1/projects/{project_id}/roles".format(project_id=project_id),
+                    "v1/projects/{project_id}/members".format(project_id=project_id),
                     data={
-                        "id": 0,
                         "role": role["id"],
-                        "rolename": rolename,
                         "user": user["id"],
-                        "username": username,
                     },
                 )
             )


### PR DESCRIPTION
# Description

Hello,

on the doccano version I'm currently using (it must but 1.8.0 the latest)

the post of a member must have changed (role and user insted of id,role,rolename,user,username)


![image](https://user-images.githubusercontent.com/51739671/182679399-92aefbfc-2370-40f9-8288-d1837ae4e487.png)

also the parsing of the roles role_info["name"] instead of role_info["rolename"]
![image](https://user-images.githubusercontent.com/51739671/182680046-c7f19dc9-e4b2-472b-ae8e-5a0a77efdc5f.png)

Have a look and have a nice day
