### PR TITLE
Adding random task ID required to upload annotated file(s)

### DIFF
--- a/doccano_api_client/__init__.py
+++ b/doccano_api_client/__init__.py
@@ -1,7 +1,7 @@
 import os
 import typing
 from urllib.parse import urljoin
-
+from random import randint
 import requests
 
 
@@ -925,6 +925,7 @@ class DoccanoClient(_Router):
             "delimiter": delimiter,
             "encoding": encoding,
             "format": format,
+            "task": randint(0, 10000), 
             "uploadIds": upload_ids,
         }
         return self.post(f"v1/projects/{project_id}/upload", json=upload_data)


### PR DESCRIPTION
# Description

At the moment file upload functionality is broken due to the fact of missing task required for celery process to initiate the upload. There is very simple fix to add random task ID in the POST request.

Fixes # (issue)
#50
