### PR TITLE
Allow for custom certificate chains

### DIFF
--- a/doccano_client/beta/client.py
+++ b/doccano_client/beta/client.py
@@ -9,10 +9,12 @@ class DoccanoClient:
 
     __slots__ = ["_base_url", "client_session"]
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, verify: str = None) -> None:
         """Initialize a Doccano client with a base url and authorization token for headers"""
         self._base_url = base_url
         self.client_session = requests.Session()
+        if verify:
+            self.client_session.verify = verify
         headers = {
             "content-type": "application/json",
             "accept": "application/json",


### PR DESCRIPTION
# Description

When hosting Doccano behind a reverse proxy with encryption (HTTPS), it is possible that the Certificate Authority used to generate the certs is not a recognized actor by openssl (actually, this is quite likely since openssl, by default trusts no one). Under these circumstances, Doccano Client will fail to connect with the server unless the cert chain is added to the client server's list of trusted certs. Adding these certs to all users' machines is cumbersome and is not viable for some less tech savvy users. 

Instead, it is much easier to share the cert chain `.pem` file amongst your team and pass this to the request Session's verify argument. 

I have added a verify argument to other DoccanoClient init function to be passed to the session. It is not as clean as a kwargs approach, but it gets the job done and solves existing issues (#21). 
