### PR TITLE
update the create_user returns documentation

### DIFF
--- a/doccano_client/client.py
+++ b/doccano_client/client.py
@@ -254,7 +254,7 @@ class DoccanoClient:
             password (str): the password to set for the new user
 
         Returns:
-            User: The UserDetails of the newly created user
+            User: the newly created user info
         """
         return self._user_repository.create_user(username=username, password=password)
 


### PR DESCRIPTION
update the create_user returns documentation in the client.py file to match what is in the docs in the user_repository

# Description

Mismatch documentation fix

Fixes # (issue)

https://github.com/doccano/doccano-client/issues/129