### PR TITLE
Add environment variable support for Doccano credentials

### DIFF
--- a/doccano_client/beta/tests/test_full_integration_tests.py
+++ b/doccano_client/beta/tests/test_full_integration_tests.py
@@ -1,13 +1,17 @@
 from unittest import TestCase
 
 import pytest
+from dotenv import load_dotenv
 
 from ..client import DoccanoClient
 from ..models import Example, Project, SpanType
+import os
 
-DOCCANO_ENDPOINT = "http://localhost"  # TODO: Make this a pytest parameter or ENV variable
-DOCCANO_USER = "admin"  # TODO: Make this a pytest parameter or ENV variable
-DOCCANO_PASS = "password"  # TODO: Make this a pytest parameter or ENV variable
+load_dotenv()
+
+DOCCANO_ENDPOINT = os.getenv("DOCCANO_ENDPOINT", "http://localhost")
+DOCCANO_USER = os.getenv("DOCCANO_USER", "admin")
+DOCCANO_PASS = os.getenv("DOCCANO_PASS", "password")
 
 
 @pytest.mark.localintegrationtest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ mkdocs-material = "^8.5.3"
 mkdocs-same-dir = "^0.1.1"
 vcrpy = "^4.2.1"
 mkdocstrings = {extras = ["python", "crystal"], version = "^0.19.0"}
+python-dotenv = "^1.0.0"
 
 [tool.poetry.extras]
 spacy = ["spacy", "spacy-partial-tagger", "tqdm"]


### PR DESCRIPTION
Updated `doccano_client` tests and project dependencies to utilize environment variables via `python-dotenv`. This enhancement allows secure and flexible configuration for different environments.

## Key Changes

1. Integrated `python-dotenv` for environment variable management.
2. Replaced hard-coded credentials in `test_full_integration_tests.py` with environment variables.
3. Added `python-dotenv` to `pyproject.toml`.

## Testing

Ensure tests pass with `.env` configurations.